### PR TITLE
Fix key selection in R.N.D

### DIFF
--- a/R.N.D/main.c
+++ b/R.N.D/main.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
 		if(strncmp(argument,"--k=",4) == 0)
 		{
 			char key_string[2] = { 0 };
-			key_string[0] = *argument + 4;
+			key_string[0] = *(argument + 4);
 			chosen_key = (int)strtol(key_string,NULL,10);
 			if(chosen_key > KEY_COUNT || chosen_key < 0)
 			{

--- a/R.N.D/main.c
+++ b/R.N.D/main.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 		}
 		
 		char argument[8] = {0};
-		memcpy(argument,argv[i],4);
+		memcpy(argument,argv[i],5);
 		
 		if(strncmp(argument,"--k=",4) == 0)
 		{


### PR DESCRIPTION
I tried to use R.N.D to decrypt the SYSTEM partition but always got garbage as a result.
Debuging showed that R.N.D. always tried to use key 1 to decrypt. This is caused by an of by one error when coping from the command line arguments  and missing parenthesises on a dereference. For me the decryption works with these patches.